### PR TITLE
Move Spotify OAuth flow to backend

### DIFF
--- a/backend/api/urls.py
+++ b/backend/api/urls.py
@@ -1,0 +1,7 @@
+from django.urls import path
+from . import views
+
+urlpatterns = [
+    path('spotify/login/', views.spotify_login, name='spotify-login'),
+    path('spotify/callback/', views.spotify_callback, name='spotify-callback'),
+]

--- a/backend/api/views.py
+++ b/backend/api/views.py
@@ -1,3 +1,57 @@
-from django.shortcuts import render
+import os
+import requests
 
-# Create your views here.
+from django.http import HttpResponseRedirect, JsonResponse, HttpResponse
+from django.urls import reverse
+from django.views.decorators.csrf import csrf_exempt
+
+
+def spotify_login(request):
+    """Redirect user to Spotify authorization page."""
+    client_id = os.environ.get("SPOTIFY_CLIENT_ID")
+    redirect_uri = request.build_absolute_uri(reverse("spotify-callback"))
+    scopes = "user-read-email playlist-read-private"
+
+    url = (
+        "https://accounts.spotify.com/authorize"
+        "?response_type=code"
+        f"&client_id={client_id}"
+        f"&redirect_uri={redirect_uri}"
+        f"&scope={scopes}"
+    )
+    return HttpResponseRedirect(url)
+
+
+@csrf_exempt
+def spotify_callback(request):
+    """Exchange the authorization code for an access token and redirect to front."""
+    code = request.GET.get("code")
+    if not code:
+        return JsonResponse({"error": "missing code"}, status=400)
+
+    token_url = "https://accounts.spotify.com/api/token"
+    client_id = os.environ.get("SPOTIFY_CLIENT_ID")
+    client_secret = os.environ.get("SPOTIFY_CLIENT_SECRET")
+    redirect_uri = request.build_absolute_uri(reverse("spotify-callback"))
+
+    data = {
+        "grant_type": "authorization_code",
+        "code": code,
+        "redirect_uri": redirect_uri,
+        "client_id": client_id,
+        "client_secret": client_secret,
+    }
+    r = requests.post(token_url, data=data)
+    if r.status_code != 200:
+        return JsonResponse({"error": "token request failed", "details": r.text}, status=400)
+
+    token_info = r.json()
+    access_token = token_info.get("access_token")
+
+    front_redirect = "http://localhost:8100/auth-callback"
+    if access_token:
+        redirect_url = f"{front_redirect}?token={access_token}"
+    else:
+        redirect_url = f"{front_redirect}?error=1"
+
+    return HttpResponseRedirect(redirect_url)

--- a/backend/backend/urls.py
+++ b/backend/backend/urls.py
@@ -15,8 +15,9 @@ Including another URLconf
     2. Add a URL to urlpatterns:  path('blog/', include('blog.urls'))
 """
 from django.contrib import admin
-from django.urls import path
+from django.urls import path, include
 
 urlpatterns = [
     path('admin/', admin.site.urls),
+    path('api/', include('api.urls')),
 ]

--- a/front/src/app/page/auth-callback/auth-callback.page.ts
+++ b/front/src/app/page/auth-callback/auth-callback.page.ts
@@ -12,7 +12,7 @@ export class AuthCallbackPage implements OnInit {
   constructor(private auth: SpotifyAuthService, private router: Router) {}
 
   async ngOnInit() {
-    await this.auth.handleAuthCallback(window.location.hash);
+    await this.auth.handleAuthCallback(window.location.search);
     await this.router.navigateByUrl('/');
   }
 }

--- a/front/src/app/services/spotify-auth.service.ts
+++ b/front/src/app/services/spotify-auth.service.ts
@@ -26,24 +26,12 @@ export class SpotifyAuthService {
   }
 
   login() {
-    const clientId = environment.spotifyClientId;
-    const redirectUri = environment.spotifyRedirectUri;
-    const scopes = [
-      'user-read-email',
-      'playlist-read-private'
-    ];
-    const url =
-      'https://accounts.spotify.com/authorize' +
-      '?response_type=token' +
-      `&client_id=${encodeURIComponent(clientId)}` +
-      `&redirect_uri=${encodeURIComponent(redirectUri)}` +
-      `&scope=${encodeURIComponent(scopes.join(' '))}`;
-    window.location.href = url;
+    window.location.href = `${environment.apiUrl}/spotify/login/`;
   }
 
-  async handleAuthCallback(hash: string) {
-    const params = new URLSearchParams(hash.replace('#', ''));
-    const token = params.get('access_token');
+  async handleAuthCallback(query: string) {
+    const params = new URLSearchParams(query.replace('?', ''));
+    const token = params.get('token');
     if (token) {
       await this.setToken(token);
     }

--- a/front/src/environments/environment.prod.ts
+++ b/front/src/environments/environment.prod.ts
@@ -3,7 +3,5 @@ declare const process: { env: { [key: string]: string | undefined } };
 export const environment = {
   production: true,
   apiUrl: 'http://localhost:8000/api',
-  spotifyClientId: process.env['SPOTIFY_CLIENT_ID'] || '',
-  spotifyClientSecret: process.env['SPOTIFY_CLIENT_SECRET'] || '',
   spotifyRedirectUri: 'http://localhost:8100/auth-callback'
 };

--- a/front/src/environments/environment.ts
+++ b/front/src/environments/environment.ts
@@ -3,7 +3,5 @@ declare const process: { env: { [key: string]: string | undefined } };
 export const environment = {
   production: false,
   apiUrl: 'http://localhost:8000/api',
-  spotifyClientId: process.env['SPOTIFY_CLIENT_ID'] || '',
-  spotifyClientSecret: process.env['SPOTIFY_CLIENT_SECRET'] || '',
   spotifyRedirectUri: 'http://localhost:8100/auth-callback'
 };


### PR DESCRIPTION
## Summary
- add Spotify auth endpoints in Django backend
- update Angular service to use backend OAuth
- tweak auth callback component
- remove unused Spotify env vars from frontend

## Testing
- `python backend/manage.py check`
- `python backend/manage.py test`
- `npm test` *(fails: `ng` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6863ca0f91a0832dae4a8c4f77639d3f