### PR TITLE
Add frontend Spotify login

### DIFF
--- a/front/README.md
+++ b/front/README.md
@@ -1,4 +1,20 @@
-build app :
+## Development
+
+Install dependencies and start the dev server:
+
+```bash
+npm install
+npm start
+```
+
+The application will be available on `http://localhost:8100`. Use the
+"Se connecter avec Spotify" button to authenticate with Spotify via the
+backend OAuth flow.
+
+### iOS Build
+
+```bash
 ionic build
 ionic cap sync ios
 ionic cap open ios
+```

--- a/front/src/app/page/auth-callback/auth-callback.page.ts
+++ b/front/src/app/page/auth-callback/auth-callback.page.ts
@@ -1,4 +1,4 @@
-import { Component, OnInit } from '@angular/core';
+import { Component, OnInit, inject } from '@angular/core';
 import { Router } from '@angular/router';
 import { IonContent, IonSpinner } from '@ionic/angular/standalone';
 import { SpotifyAuthService } from '../../services/spotify-auth.service';
@@ -9,7 +9,8 @@ import { SpotifyAuthService } from '../../services/spotify-auth.service';
   imports: [IonContent, IonSpinner]
 })
 export class AuthCallbackPage implements OnInit {
-  constructor(private auth: SpotifyAuthService, private router: Router) {}
+  private auth = inject(SpotifyAuthService);
+  private router = inject(Router);
 
   async ngOnInit() {
     await this.auth.handleAuthCallback(window.location.search);

--- a/front/src/app/page/login/login.page.ts
+++ b/front/src/app/page/login/login.page.ts
@@ -1,4 +1,4 @@
-import { Component, OnInit } from '@angular/core';
+import { Component, OnInit, inject } from '@angular/core';
 import { Router } from '@angular/router';
 import { IonContent, IonButton, IonHeader, IonToolbar, IonTitle } from '@ionic/angular/standalone';
 import { SpotifyAuthService } from '../../services/spotify-auth.service';
@@ -10,7 +10,8 @@ import { SpotifyAuthService } from '../../services/spotify-auth.service';
   imports: [IonContent, IonButton, IonHeader, IonToolbar, IonTitle]
 })
 export class LoginPage implements OnInit {
-  constructor(private auth: SpotifyAuthService, private router: Router) {}
+  private auth = inject(SpotifyAuthService);
+  private router = inject(Router);
 
   async ngOnInit() {
     const token = await this.auth.getToken();

--- a/front/src/app/services/auth.guard.ts
+++ b/front/src/app/services/auth.guard.ts
@@ -1,4 +1,4 @@
-import { Injectable } from '@angular/core';
+import { Injectable, inject } from '@angular/core';
 import { CanActivate, Router } from '@angular/router';
 import { SpotifyAuthService } from './spotify-auth.service';
 
@@ -6,7 +6,8 @@ import { SpotifyAuthService } from './spotify-auth.service';
   providedIn: 'root'
 })
 export class AuthGuard implements CanActivate {
-  constructor(private auth: SpotifyAuthService, private router: Router) {}
+  private auth = inject(SpotifyAuthService);
+  private router = inject(Router);
 
   async canActivate(): Promise<boolean> {
     const token = await this.auth.getToken();

--- a/front/src/app/services/external-api-management.service.ts
+++ b/front/src/app/services/external-api-management.service.ts
@@ -1,4 +1,4 @@
-import { Injectable } from '@angular/core';
+import { Injectable, inject } from '@angular/core';
 import {HttpClient} from "@angular/common/http";
 import {Observable} from "rxjs";
 import {queryParams} from "./api-management.service";
@@ -7,7 +7,7 @@ import {queryParams} from "./api-management.service";
   providedIn: 'root'
 })
 export class ExternalApiManagementService {
-  constructor(private _http: HttpClient) {}
+  private _http = inject(HttpClient);
 
   get<T>(url: string, options: {
     params?: queryParams,

--- a/front/src/main.ts
+++ b/front/src/main.ts
@@ -1,6 +1,7 @@
 import { bootstrapApplication } from '@angular/platform-browser';
 import { RouteReuseStrategy, provideRouter, withPreloading, PreloadAllModules } from '@angular/router';
 import { IonicRouteStrategy, provideIonicAngular } from '@ionic/angular/standalone';
+import { provideHttpClient } from '@angular/common/http';
 
 import { routes } from './app/app.routes';
 import { AppComponent } from './app/app.component';
@@ -9,6 +10,7 @@ bootstrapApplication(AppComponent, {
   providers: [
     { provide: RouteReuseStrategy, useClass: IonicRouteStrategy },
     provideIonicAngular(),
+    provideHttpClient(),
     provideRouter(routes, withPreloading(PreloadAllModules)),
   ],
 });


### PR DESCRIPTION
## Summary
- provide HttpClient in Ionic bootstrap
- update Ionic README with dev instructions
- use Angular's `inject` function for services

## Testing
- `npm run lint --silent`
- `npm test --silent` *(fails: No binary for Chrome browser)*

------
https://chatgpt.com/codex/tasks/task_e_6863cb9716b0832d90fa0ba32dbb2496