### PR TITLE
Add API management service

### DIFF
--- a/frontend/services/api.ts
+++ b/frontend/services/api.ts
@@ -1,0 +1,44 @@
+const API_BASE_URL = process.env.EXPO_PUBLIC_API_URL || 'http://localhost:8000/api';
+
+interface RequestOptions {
+  headers?: Record<string, string>;
+}
+
+async function request<T>(method: string, path: string, body?: unknown, options: RequestOptions = {}): Promise<T> {
+  const response = await fetch(`${API_BASE_URL}${path}`, {
+    method,
+    headers: {
+      'Content-Type': 'application/json',
+      ...(options.headers ?? {}),
+    },
+    body: body ? JSON.stringify(body) : undefined,
+  });
+
+  if (!response.ok) {
+    const errorText = await response.text();
+    throw new Error(errorText || response.statusText);
+  }
+
+  if (response.status === 204) {
+    return undefined as T;
+  }
+
+  return (await response.json()) as T;
+}
+
+export const api = {
+  get<T>(path: string, options?: RequestOptions) {
+    return request<T>('GET', path, undefined, options);
+  },
+  post<T>(path: string, body?: unknown, options?: RequestOptions) {
+    return request<T>('POST', path, body, options);
+  },
+  patch<T>(path: string, body?: unknown, options?: RequestOptions) {
+    return request<T>('PATCH', path, body, options);
+  },
+  delete<T>(path: string, body?: unknown, options?: RequestOptions) {
+    return request<T>('DELETE', path, body, options);
+  },
+};
+
+export default api;


### PR DESCRIPTION
## Summary
- add a generic API service to manage requests in the frontend

## Testing
- `npm run lint` *(fails: expo not found)*

------
https://chatgpt.com/codex/tasks/task_e_6865179fd5e4832db3802e29bc9fc660