### PR TITLE
Implement OAuth callback handling

### DIFF
--- a/backend/api/test_views.py
+++ b/backend/api/test_views.py
@@ -1,0 +1,27 @@
+from django.test import TestCase
+from django.urls import reverse
+from unittest.mock import patch
+from requests.models import Response
+
+class SpotifyTokenTests(TestCase):
+    def mock_post(self, url, data=None, **kwargs):
+        self.captured_url = url
+        self.captured_data = data
+        response = Response()
+        response.status_code = 200
+        response._content = b'{"access_token": "abc", "refresh_token": "def"}'
+        return response
+
+    @patch('api.views.requests.post')
+    def test_exchange_code(self, mock_post):
+        mock_post.side_effect = self.mock_post
+        response = self.client.post(reverse('spotify-token'), {'code': '123'})
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(self.captured_url, 'https://accounts.spotify.com/api/token')
+        self.assertIn('123', self.captured_data['code'])
+        self.assertEqual(response.json()['access_token'], 'abc')
+
+    def test_missing_code(self):
+        response = self.client.post(reverse('spotify-token'), {})
+        self.assertEqual(response.status_code, 400)
+

--- a/backend/api/tests.py
+++ b/backend/api/tests.py
@@ -1,3 +1,0 @@
-from django.test import TestCase
-
-# Create your tests here.

--- a/frontend/app/_layout.tsx
+++ b/frontend/app/_layout.tsx
@@ -20,6 +20,8 @@ export default function RootLayout() {
   return (
     <ThemeProvider value={colorScheme === 'dark' ? DarkTheme : DefaultTheme}>
       <Stack>
+        <Stack.Screen name="login" options={{ title: 'Login' }} />
+        <Stack.Screen name="callback" options={{ headerShown: false }} />
         <Stack.Screen name="(tabs)" options={{ headerShown: false }} />
         <Stack.Screen name="+not-found" />
       </Stack>

--- a/frontend/app/callback.tsx
+++ b/frontend/app/callback.tsx
@@ -1,0 +1,33 @@
+import { useEffect } from 'react';
+import { ActivityIndicator, View } from 'react-native';
+import { useLocalSearchParams, useRouter } from 'expo-router';
+
+import api from '@/services/api';
+
+export default function CallbackScreen() {
+  const router = useRouter();
+  const { code } = useLocalSearchParams<{ code?: string }>();
+
+  useEffect(() => {
+    async function exchange() {
+      if (!code) {
+        router.replace('/login');
+        return;
+      }
+      try {
+        await api.post('/spotify/token/', { code });
+        router.replace('/(tabs)');
+      } catch (e) {
+        console.error(e);
+        router.replace('/login');
+      }
+    }
+    exchange();
+  }, [code]);
+
+  return (
+    <View style={{ flex: 1, alignItems: 'center', justifyContent: 'center' }}>
+      <ActivityIndicator />
+    </View>
+  );
+}

--- a/frontend/app/login.tsx
+++ b/frontend/app/login.tsx
@@ -1,0 +1,43 @@
+import { useState } from 'react';
+import { Button, View } from 'react-native';
+import * as AuthSession from 'expo-auth-session';
+import { useRouter } from 'expo-router';
+
+
+const clientId = process.env.EXPO_PUBLIC_SPOTIFY_CLIENT_ID ?? '';
+const scopes = 'user-read-email playlist-read-private';
+const discovery = {
+  authorizationEndpoint: 'https://accounts.spotify.com/authorize',
+};
+
+export default function LoginScreen() {
+  const router = useRouter();
+  const [loading, setLoading] = useState(false);
+
+  async function handleLogin() {
+    const redirectUri = AuthSession.makeRedirectUri({
+      scheme: 'frontend',
+      path: 'callback',
+    });
+    const params = new URLSearchParams({
+      response_type: 'code',
+      client_id: clientId,
+      redirect_uri: redirectUri,
+      scope: scopes,
+    });
+    const authUrl = `${discovery.authorizationEndpoint}?${params.toString()}`;
+
+    setLoading(true);
+    const result = await AuthSession.startAsync({ authUrl, returnUrl: redirectUri });
+    if (result.type === 'success' && result.params?.code) {
+      router.replace({ pathname: '/callback', params: { code: result.params.code } });
+    }
+    setLoading(false);
+  }
+
+  return (
+    <View style={{ flex: 1, alignItems: 'center', justifyContent: 'center' }}>
+      <Button title="Se connecter avec Spotify" onPress={handleLogin} disabled={loading} />
+    </View>
+  );
+}

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -13,6 +13,7 @@
         "@react-navigation/elements": "^2.3.8",
         "@react-navigation/native": "^7.1.6",
         "expo": "~53.0.15",
+        "expo-auth-session": "^6.2.0",
         "expo-blur": "~14.1.5",
         "expo-constants": "~17.1.6",
         "expo-font": "~13.3.2",
@@ -5753,6 +5754,15 @@
         }
       }
     },
+    "node_modules/expo-application": {
+      "version": "6.1.5",
+      "resolved": "https://registry.npmjs.org/expo-application/-/expo-application-6.1.5.tgz",
+      "integrity": "sha512-ToImFmzw8luY043pWFJhh2ZMm4IwxXoHXxNoGdlhD4Ym6+CCmkAvCglg0FK8dMLzAb+/XabmOE7Rbm8KZb6NZg==",
+      "license": "MIT",
+      "peerDependencies": {
+        "expo": "*"
+      }
+    },
     "node_modules/expo-asset": {
       "version": "11.1.6",
       "resolved": "https://registry.npmjs.org/expo-asset/-/expo-asset-11.1.6.tgz",
@@ -5764,6 +5774,34 @@
       "peerDependencies": {
         "expo": "*",
         "react": "*",
+        "react-native": "*"
+      }
+    },
+    "node_modules/expo-auth-session": {
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/expo-auth-session/-/expo-auth-session-6.2.0.tgz",
+      "integrity": "sha512-oxeyct1gYFtkP6IajckbNAXcNq3F4+9trmr7tAGMQXjX7ghilmOWVizBONDXA7BWZQ/UTJoBYnKgvZyMB/54cg==",
+      "license": "MIT",
+      "dependencies": {
+        "expo-application": "~6.1.4",
+        "expo-constants": "~17.1.6",
+        "expo-crypto": "~14.1.4",
+        "expo-linking": "~7.1.5",
+        "expo-web-browser": "~14.1.6",
+        "invariant": "^2.2.4"
+      },
+      "peerDependencies": {
+        "react": "*",
+        "react-native": "*"
+      }
+    },
+    "node_modules/expo-auth-session/node_modules/expo-web-browser": {
+      "version": "14.1.6",
+      "resolved": "https://registry.npmjs.org/expo-web-browser/-/expo-web-browser-14.1.6.tgz",
+      "integrity": "sha512-/4P8eWqRyfXIMZna3acg320LXNA+P2cwyEVbjDX8vHnWU+UnOtyRKWy3XaAIyMPQ9hVjBNUQTh4MPvtnPRzakw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "expo": "*",
         "react-native": "*"
       }
     },
@@ -5788,6 +5826,18 @@
       "peerDependencies": {
         "expo": "*",
         "react-native": "*"
+      }
+    },
+    "node_modules/expo-crypto": {
+      "version": "14.1.5",
+      "resolved": "https://registry.npmjs.org/expo-crypto/-/expo-crypto-14.1.5.tgz",
+      "integrity": "sha512-ZXJoUMoUeiMNEoSD4itItFFz3cKrit6YJ/BR0hjuwNC+NczbV9rorvhvmeJmrU9O2cFQHhJQQR1fjQnt45Vu4Q==",
+      "license": "MIT",
+      "dependencies": {
+        "base64-js": "^1.3.0"
+      },
+      "peerDependencies": {
+        "expo": "*"
       }
     },
     "node_modules/expo-file-system": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -16,6 +16,7 @@
     "@react-navigation/elements": "^2.3.8",
     "@react-navigation/native": "^7.1.6",
     "expo": "~53.0.15",
+    "expo-auth-session": "^6.2.0",
     "expo-blur": "~14.1.5",
     "expo-constants": "~17.1.6",
     "expo-font": "~13.3.2",
@@ -41,9 +42,9 @@
   "devDependencies": {
     "@babel/core": "^7.25.2",
     "@types/react": "~19.0.10",
-    "typescript": "~5.8.3",
     "eslint": "^9.25.0",
-    "eslint-config-expo": "~9.2.0"
+    "eslint-config-expo": "~9.2.0",
+    "typescript": "~5.8.3"
   },
   "private": true
 }


### PR DESCRIPTION
## Summary
- handle OAuth callback in a dedicated screen
- navigate to callback after Spotify login
- cover token exchange endpoint with tests

## Testing
- `npm -C frontend run lint` *(fails: expo not found)*
- `DJANGO_SETTINGS_MODULE=backend.settings pytest -q` *(fails: PostgreSQL not running)*

------
https://chatgpt.com/codex/tasks/task_e_686519908d48832db3c997d1c7002266