### PR TITLE
Add auth guard and main page

### DIFF
--- a/frontend/app/_layout.tsx
+++ b/frontend/app/_layout.tsx
@@ -5,6 +5,8 @@ import { StatusBar } from 'expo-status-bar';
 import 'react-native-reanimated';
 
 import { useColorScheme } from 'react-native';
+import { AuthProvider } from '../services/auth';
+import AuthGuard from '../services/AuthGuard';
 
 export default function RootLayout() {
   const colorScheme = useColorScheme();
@@ -19,11 +21,16 @@ export default function RootLayout() {
 
   return (
     <ThemeProvider value={colorScheme === 'dark' ? DarkTheme : DefaultTheme}>
-      <Stack>
-        <Stack.Screen name="login" options={{ title: 'Login' }} />
-        <Stack.Screen name="callback" options={{ headerShown: false }} />
-        <Stack.Screen name="connected" options={{ title: 'Connected' }} />
-      </Stack>
+      <AuthProvider>
+        <AuthGuard>
+          <Stack>
+            <Stack.Screen name="index" options={{ title: 'Home' }} />
+            <Stack.Screen name="login" options={{ title: 'Login' }} />
+            <Stack.Screen name="callback" options={{ headerShown: false }} />
+            <Stack.Screen name="connected" options={{ title: 'Connected' }} />
+          </Stack>
+        </AuthGuard>
+      </AuthProvider>
       <StatusBar style="auto" />
     </ThemeProvider>
   );

--- a/frontend/app/callback.tsx
+++ b/frontend/app/callback.tsx
@@ -2,11 +2,13 @@ import { useEffect } from 'react';
 import { ActivityIndicator, View } from 'react-native';
 import { useLocalSearchParams, useRouter } from 'expo-router';
 
-import api from '@/services/api';
+import api from '../services/api';
+import { useAuth, TokenData } from '../services/auth';
 
 export default function CallbackScreen() {
   const router = useRouter();
   const { code } = useLocalSearchParams<{ code?: string }>();
+  const { setToken } = useAuth();
 
   useEffect(() => {
     async function exchange() {
@@ -15,7 +17,8 @@ export default function CallbackScreen() {
         return;
       }
       try {
-        await api.post('/spotify/token/', { code });
+        const data = await api.post<TokenData>('/spotify/token/', { code });
+        await setToken(data);
         router.replace('/connected');
       } catch (e) {
         console.error(e);
@@ -23,7 +26,7 @@ export default function CallbackScreen() {
       }
     }
     exchange();
-  }, [code]);
+  }, [code, router, setToken]);
 
   return (
     <View style={{ flex: 1, alignItems: 'center', justifyContent: 'center' }}>

--- a/frontend/app/connected.tsx
+++ b/frontend/app/connected.tsx
@@ -1,9 +1,12 @@
-import { View, Text } from 'react-native';
+import { View, Text, Button } from 'react-native';
+import { useRouter } from 'expo-router';
 
 export default function ConnectedScreen() {
+  const router = useRouter();
   return (
     <View style={{ flex: 1, alignItems: 'center', justifyContent: 'center' }}>
-      <Text style={{color:"white"}}>Connexion à Spotify réussie !</Text>
+      <Text style={{ color: 'white', marginBottom: 20 }}>Connexion à Spotify réussie !</Text>
+      <Button title="Accéder à l'application" onPress={() => router.replace('/')} />
     </View>
   );
 }

--- a/frontend/app/index.tsx
+++ b/frontend/app/index.tsx
@@ -1,0 +1,9 @@
+import { View, Text } from 'react-native';
+
+export default function HomeScreen() {
+  return (
+    <View style={{ flex: 1, alignItems: 'center', justifyContent: 'center' }}>
+      <Text style={{ color: 'white' }}>Bienvenue sur MoodSound !</Text>
+    </View>
+  );
+}

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -21,6 +21,7 @@
         "expo-image": "~2.3.1",
         "expo-linking": "~7.1.6",
         "expo-router": "~5.1.2",
+        "expo-secure-store": "^14.2.3",
         "expo-splash-screen": "~0.30.9",
         "expo-status-bar": "~2.2.3",
         "expo-symbols": "~0.4.5",
@@ -5982,6 +5983,15 @@
       },
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/expo-secure-store": {
+      "version": "14.2.3",
+      "resolved": "https://registry.npmjs.org/expo-secure-store/-/expo-secure-store-14.2.3.tgz",
+      "integrity": "sha512-hYBbaAD70asKTFd/eZBKVu+9RTo9OSTMMLqXtzDF8ndUGjpc6tmRCoZtrMHlUo7qLtwL5jm+vpYVBWI8hxh/1Q==",
+      "license": "MIT",
+      "peerDependencies": {
+        "expo": "*"
       }
     },
     "node_modules/expo-splash-screen": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -24,6 +24,7 @@
     "expo-image": "~2.3.1",
     "expo-linking": "~7.1.6",
     "expo-router": "~5.1.2",
+    "expo-secure-store": "^14.2.3",
     "expo-splash-screen": "~0.30.9",
     "expo-status-bar": "~2.2.3",
     "expo-symbols": "~0.4.5",

--- a/frontend/services/AuthGuard.tsx
+++ b/frontend/services/AuthGuard.tsx
@@ -1,0 +1,26 @@
+import { useRouter, useSegments } from 'expo-router';
+import { useEffect } from 'react';
+import { useAuth } from './auth';
+
+export default function AuthGuard({ children }: { children: React.ReactNode }) {
+  const { isAuthenticated, loading } = useAuth();
+  const segments = useSegments();
+  const router = useRouter();
+
+  useEffect(() => {
+    if (loading) return;
+    const inAuthFlow = segments[0] === 'login' || segments[0] === 'callback';
+    if (!isAuthenticated && !inAuthFlow) {
+      router.replace('/login');
+    }
+    if (isAuthenticated && inAuthFlow) {
+      router.replace('/');
+    }
+  }, [segments, isAuthenticated, loading]);
+
+  if (loading) {
+    return null;
+  }
+
+  return <>{children}</>;
+}

--- a/frontend/services/auth.tsx
+++ b/frontend/services/auth.tsx
@@ -1,0 +1,62 @@
+import React, { createContext, useContext, useState, useEffect } from 'react';
+import * as SecureStore from 'expo-secure-store';
+
+export interface TokenData {
+  access_token: string;
+  expires_in: number;
+}
+
+const TOKEN_KEY = 'spotify_token';
+const EXPIRES_KEY = 'spotify_token_expires';
+
+interface AuthContextValue {
+  token: string | null;
+  isAuthenticated: boolean;
+  loading: boolean;
+  setToken: (data: TokenData) => Promise<void>;
+  logout: () => Promise<void>;
+}
+
+const AuthContext = createContext<AuthContextValue | undefined>(undefined);
+
+export function AuthProvider({ children }: { children: React.ReactNode }) {
+  const [token, setTokenState] = useState<string | null>(null);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    async function load() {
+      const stored = await SecureStore.getItemAsync(TOKEN_KEY);
+      const expires = await SecureStore.getItemAsync(EXPIRES_KEY);
+      if (stored && expires && parseInt(expires, 10) > Date.now() / 1000) {
+        setTokenState(stored);
+      }
+      setLoading(false);
+    }
+    load();
+  }, []);
+
+  const setToken = async (data: TokenData) => {
+    const expiresAt = Math.floor(Date.now() / 1000 + data.expires_in - 60);
+    await SecureStore.setItemAsync(TOKEN_KEY, data.access_token);
+    await SecureStore.setItemAsync(EXPIRES_KEY, expiresAt.toString());
+    setTokenState(data.access_token);
+  };
+
+  const logout = async () => {
+    await SecureStore.deleteItemAsync(TOKEN_KEY);
+    await SecureStore.deleteItemAsync(EXPIRES_KEY);
+    setTokenState(null);
+  };
+
+  return (
+    <AuthContext.Provider value={{ token, isAuthenticated: !!token, loading, setToken, logout }}>
+      {children}
+    </AuthContext.Provider>
+  );
+}
+
+export function useAuth() {
+  const ctx = useContext(AuthContext);
+  if (!ctx) throw new Error('useAuth must be used within AuthProvider');
+  return ctx;
+}


### PR DESCRIPTION
## Summary
- add a token-based auth context with secure storage
- create an AuthGuard component and use it in the router
- add home page with '/' route
- store access token after Spotify callback
- allow navigation to home from connected page
- install expo-secure-store dependency

## Testing
- `npm run lint`
- `python manage.py test` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_68652d801160832da9cb563ab2595ff4