### PR TITLE
Add global header with logout button

### DIFF
--- a/frontend/app/_layout.tsx
+++ b/frontend/app/_layout.tsx
@@ -7,6 +7,7 @@ import 'react-native-reanimated';
 import { useColorScheme } from 'react-native';
 import { AuthProvider } from '../services/auth';
 import AuthGuard from '../services/AuthGuard';
+import Header from '../components/Header';
 
 export default function RootLayout() {
   const colorScheme = useColorScheme();
@@ -23,6 +24,7 @@ export default function RootLayout() {
     <ThemeProvider value={colorScheme === 'dark' ? DarkTheme : DefaultTheme}>
       <AuthProvider>
         <AuthGuard>
+          <Header />
           <Stack>
             <Stack.Screen name="index" options={{ title: 'Home' }} />
             <Stack.Screen name="login" options={{ title: 'Login' }} />

--- a/frontend/components/Header.tsx
+++ b/frontend/components/Header.tsx
@@ -1,0 +1,25 @@
+import React from 'react';
+import { View, Button } from 'react-native';
+import { useSafeAreaInsets } from 'react-native-safe-area-context';
+import { useAuth } from '../services/auth';
+
+export default function Header() {
+  const insets = useSafeAreaInsets();
+  const { logout, isAuthenticated } = useAuth();
+
+  if (!isAuthenticated) return null;
+
+  return (
+    <View
+      style={{
+        paddingTop: insets.top,
+        paddingBottom: 10,
+        backgroundColor: '#222',
+        alignItems: 'flex-end',
+        paddingHorizontal: 10,
+      }}
+    >
+      <Button title="Logout" onPress={logout} />
+    </View>
+  );
+}


### PR DESCRIPTION
## Summary
- add reusable header component displaying a logout button
- render the header for authenticated pages

## Testing
- `python backend/manage.py test` *(fails: settings.DATABASES is improperly configured)*

------
https://chatgpt.com/codex/tasks/task_e_686534ef8744832dbd1d1d80041b5a6f