### PR TITLE
Add mood test navigation

### DIFF
--- a/frontend/app/_layout.tsx
+++ b/frontend/app/_layout.tsx
@@ -30,6 +30,7 @@ export default function RootLayout() {
             <Stack.Screen name="login" options={{ title: 'Login' }} />
             <Stack.Screen name="callback" options={{ headerShown: false }} />
             <Stack.Screen name="connected" options={{ title: 'Connected' }} />
+            <Stack.Screen name="test-mood" options={{ title: 'Test Mood' }} />
           </Stack>
         </AuthGuard>
       </AuthProvider>

--- a/frontend/app/index.tsx
+++ b/frontend/app/index.tsx
@@ -1,10 +1,12 @@
-import { View, Text } from 'react-native';
+import { View, Text, Button } from 'react-native';
 import { useEffect } from 'react';
+import { useRouter } from 'expo-router';
 import api from '../services/api';
 import { useAuth } from '../services/auth';
 
 export default function HomeScreen() {
   const { token } = useAuth();
+  const router = useRouter();
 
   useEffect(() => {
     async function fetchFavorites() {
@@ -23,6 +25,10 @@ export default function HomeScreen() {
   return (
     <View style={{ flex: 1, alignItems: 'center', justifyContent: 'center' }}>
       <Text style={{ color: 'white' }}>Bienvenue sur MoodSound !</Text>
+      <Button
+        title="Tester mon mood"
+        onPress={() => router.push('/test-mood')}
+      />
     </View>
   );
 }

--- a/frontend/app/test-mood.tsx
+++ b/frontend/app/test-mood.tsx
@@ -1,0 +1,28 @@
+import { View, Text, Button } from 'react-native';
+import { useState } from 'react';
+import { useRouter } from 'expo-router';
+
+export default function TestMoodScreen() {
+  const [step, setStep] = useState(1);
+  const router = useRouter();
+
+  const next = () => {
+    if (step < 3) {
+      setStep(step + 1);
+    } else {
+      router.replace('/');
+    }
+  };
+
+  let message;
+  if (step === 1) message = 'Étape 1';
+  else if (step === 2) message = 'Étape 2';
+  else message = 'Étape 3';
+
+  return (
+    <View style={{ flex: 1, alignItems: 'center', justifyContent: 'center' }}>
+      <Text style={{ color: 'white', marginBottom: 20 }}>{message}</Text>
+      <Button title={step < 3 ? 'Suivant' : 'Terminer'} onPress={next} />
+    </View>
+  );
+}


### PR DESCRIPTION
## Summary
- add button on home page to navigate to a new mood test screen
- implement a three-step mood test placeholder page
- declare new screen in router stack

## Testing
- `npm run lint` *(fails: expo not found)*

------
https://chatgpt.com/codex/tasks/task_e_686542400af0832db4c7d27f5e939d2b