### PR TITLE
Implement step components for test-mood

### DIFF
--- a/frontend/app/test-mood.tsx
+++ b/frontend/app/test-mood.tsx
@@ -1,6 +1,9 @@
-import { View, Text, Button } from 'react-native';
+import { View, Button } from 'react-native';
 import { useState } from 'react';
 import { useRouter } from 'expo-router';
+import CameraStep from '../components/CameraStep';
+import MicrophoneStep from '../components/MicrophoneStep';
+import ActivityStep from '../components/ActivityStep';
 
 export default function TestMoodScreen() {
   const [step, setStep] = useState(1);
@@ -14,14 +17,14 @@ export default function TestMoodScreen() {
     }
   };
 
-  let message;
-  if (step === 1) message = 'Étape 1';
-  else if (step === 2) message = 'Étape 2';
-  else message = 'Étape 3';
+  let content;
+  if (step === 1) content = <CameraStep />;
+  else if (step === 2) content = <MicrophoneStep />;
+  else content = <ActivityStep />;
 
   return (
     <View style={{ flex: 1, alignItems: 'center', justifyContent: 'center' }}>
-      <Text style={{ color: 'white', marginBottom: 20 }}>{message}</Text>
+      {content}
       <Button title={step < 3 ? 'Suivant' : 'Terminer'} onPress={next} />
     </View>
   );

--- a/frontend/components/ActivityStep.tsx
+++ b/frontend/components/ActivityStep.tsx
@@ -1,0 +1,9 @@
+import { View, Text } from 'react-native';
+
+export default function ActivityStep() {
+  return (
+    <View style={{ alignItems: 'center', justifyContent: 'center' }}>
+      <Text style={{ color: 'white' }}>Activity step</Text>
+    </View>
+  );
+}

--- a/frontend/components/CameraStep.tsx
+++ b/frontend/components/CameraStep.tsx
@@ -1,0 +1,9 @@
+import { View, Text } from 'react-native';
+
+export default function CameraStep() {
+  return (
+    <View style={{ alignItems: 'center', justifyContent: 'center' }}>
+      <Text style={{ color: 'white' }}>Camera step</Text>
+    </View>
+  );
+}

--- a/frontend/components/MicrophoneStep.tsx
+++ b/frontend/components/MicrophoneStep.tsx
@@ -1,0 +1,9 @@
+import { View, Text } from 'react-native';
+
+export default function MicrophoneStep() {
+  return (
+    <View style={{ alignItems: 'center', justifyContent: 'center' }}>
+      <Text style={{ color: 'white' }}>Microphone step</Text>
+    </View>
+  );
+}


### PR DESCRIPTION
## Summary
- add Camera, Microphone and Activity step components
- update `test-mood` screen to display a component per step

## Testing
- `npm run lint` *(fails: expo not found)*
- `python manage.py test` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_686544270788832d8264c35aa11f7512