### PR TITLE
Set up Expo router with AuthGuard

### DIFF
--- a/my-expo-app/App.tsx
+++ b/my-expo-app/App.tsx
@@ -1,16 +1,29 @@
-import { ScreenContent } from './app/ScreenContent';
 import { StatusBar } from 'expo-status-bar';
-
+import { Stack } from 'expo-router';
+import { DarkTheme, DefaultTheme, ThemeProvider } from '@react-navigation/native';
+import { useColorScheme } from 'react-native';
 import './global.css';
-import {AuthProvider} from "./services/auth";
+import { AuthProvider } from './services/auth';
+import AuthGuard from './services/AuthGuard';
+import Header from './app/Header';
 
 export default function App() {
+  const colorScheme = useColorScheme();
   return (
-    <>
-        <AuthProvider>
-                <ScreenContent title="Home" path="App.tsx"></ScreenContent>
-                <StatusBar style="auto" />
-        </AuthProvider>
-    </>
+    <ThemeProvider value={colorScheme === 'dark' ? DarkTheme : DefaultTheme}>
+      <AuthProvider>
+        <AuthGuard>
+          <Header />
+          <Stack>
+            <Stack.Screen name="index" options={{ title: 'Home' }} />
+            <Stack.Screen name="login" options={{ title: 'Login' }} />
+            <Stack.Screen name="callback" options={{ headerShown: false }} />
+            <Stack.Screen name="connected" options={{ title: 'Connected' }} />
+            <Stack.Screen name="test-mood" options={{ title: 'Test Mood' }} />
+          </Stack>
+        </AuthGuard>
+      </AuthProvider>
+      <StatusBar style="auto" />
+    </ThemeProvider>
   );
 }

--- a/my-expo-app/app.json
+++ b/my-expo-app/app.json
@@ -12,7 +12,7 @@
       "tsconfigPaths": true
     },
 
-    "plugins": [],
+    "plugins": ["expo-router"],
 
     "orientation": "portrait",
     "icon": "./assets/icon.png",

--- a/my-expo-app/app/index.tsx
+++ b/my-expo-app/app/index.tsx
@@ -1,0 +1,34 @@
+import { View, Text, Button } from 'react-native';
+import { useEffect } from 'react';
+import api from '../services/api';
+import { useAuth } from '../services/auth';
+import {useRouter} from "expo-router";
+
+export default function HomeScreen() {
+    const { token } = useAuth();
+    const router = useRouter();
+
+    useEffect(() => {
+        async function fetchFavorites() {
+            if (!token) return;
+            try {
+                await api.get('/spotify/favorites/', {
+                    headers: { Authorization: `Bearer ${token}` },
+                });
+            } catch (e) {
+                console.error(e);
+            }
+        }
+        fetchFavorites();
+    }, [token]);
+
+    return (
+        <View style={{ flex: 1, alignItems: 'center', justifyContent: 'center' }}>
+            <Text className="mb-4 text-2xl" style={{color: "white"}}>Bienvenue sur MoodSound !</Text>
+            <Button
+                title="Tester mon mood"
+                onPress={() => router.push('/test-mood')}
+            />
+        </View>
+    );
+}

--- a/my-expo-app/package.json
+++ b/my-expo-app/package.json
@@ -35,6 +35,6 @@
     "tailwindcss": "^3.4.0",
     "typescript": "~5.8.3"
   },
-  "main": "node_modules/expo/AppEntry.js",
+  "main": "expo-router/entry",
   "private": true
 }


### PR DESCRIPTION
## Summary
- enable Expo Router entry and plugin
- route everything in `App.tsx` using `<Stack />` and `AuthGuard`
- add home screen under `app/index.tsx`

## Testing
- `npm run lint` *(fails: Cannot find module 'eslint/config')*

------
https://chatgpt.com/codex/tasks/task_e_6865a181acf8832d8640e914975a80ce