### PR TITLE
Integrate Spotify auth flow

### DIFF
--- a/moodsound_app/src/app/_layout.tsx
+++ b/moodsound_app/src/app/_layout.tsx
@@ -6,6 +6,9 @@ import * as SplashScreen from 'expo-splash-screen';
 import { useEffect } from 'react';
 
 import { useColorScheme } from '@/src/components/useColorScheme';
+import { AuthProvider } from '@/src/services/auth';
+import AuthGuard from '@/src/services/AuthGuard';
+import Header from '@/src/components/Header';
 
 // Import your global CSS file
 import "../../global.css"
@@ -52,10 +55,19 @@ function RootLayoutNav() {
 
   return (
     <ThemeProvider value={colorScheme === 'dark' ? DarkTheme : DefaultTheme}>
-      <Stack>
-        <Stack.Screen name="(tabs)" options={{ headerShown: false }} />
-        <Stack.Screen name="modal" options={{ presentation: 'modal' }} />
-      </Stack>
+      <AuthProvider>
+        <AuthGuard>
+          <Header />
+          <Stack>
+            <Stack.Screen name="(tabs)" options={{ headerShown: false }} />
+            <Stack.Screen name="login" options={{ title: 'Login' }} />
+            <Stack.Screen name="callback" options={{ headerShown: false }} />
+            <Stack.Screen name="connected" options={{ title: 'Connected' }} />
+            <Stack.Screen name="test-mood" options={{ title: 'Test Mood' }} />
+            <Stack.Screen name="modal" options={{ presentation: 'modal' }} />
+          </Stack>
+        </AuthGuard>
+      </AuthProvider>
     </ThemeProvider>
   );
 }

--- a/moodsound_app/src/app/callback.tsx
+++ b/moodsound_app/src/app/callback.tsx
@@ -1,0 +1,35 @@
+import { useEffect } from 'react';
+import { ActivityIndicator, View } from 'react-native';
+import { useLocalSearchParams, useRouter } from 'expo-router';
+
+import api from '../services/api';
+import { useAuth, TokenData } from '../services/auth';
+
+export default function CallbackScreen() {
+  const router = useRouter();
+  const { code } = useLocalSearchParams<{ code?: string }>();
+  const { setToken } = useAuth();
+
+  useEffect(() => {
+    async function exchange() {
+      if (!code) {
+        router.replace('/login');
+        return;
+      }
+      try {
+        const data = await api.post<TokenData>('/spotify/token/', { code });
+        await setToken(data);
+        router.replace('/connected');
+      } catch (e) {
+        router.replace('/login');
+      }
+    }
+    exchange();
+  }, [code, router, setToken]);
+
+  return (
+    <View style={{ flex: 1, alignItems: 'center', justifyContent: 'center' }}>
+      <ActivityIndicator />
+    </View>
+  );
+}

--- a/moodsound_app/src/app/connected.tsx
+++ b/moodsound_app/src/app/connected.tsx
@@ -1,0 +1,12 @@
+import { View, Text, Button } from 'react-native';
+import { useRouter } from 'expo-router';
+
+export default function ConnectedScreen() {
+  const router = useRouter();
+  return (
+    <View style={{ flex: 1, alignItems: 'center', justifyContent: 'center' }}>
+      <Text style={{ color: 'white', marginBottom: 20 }}>Connexion à Spotify réussie !</Text>
+      <Button title="Accéder à l'application" onPress={() => router.replace('/')} />
+    </View>
+  );
+}

--- a/moodsound_app/src/app/login.tsx
+++ b/moodsound_app/src/app/login.tsx
@@ -1,0 +1,46 @@
+import React, { useState } from 'react';
+import { Button, View } from 'react-native';
+import * as AuthSession from 'expo-auth-session';
+import { useRouter } from 'expo-router';
+import { makeRedirectUri } from 'expo-auth-session';
+import { REDIRECT_URL } from '../services/api';
+
+const discovery = {
+  authorizationEndpoint: 'https://accounts.spotify.com/authorize',
+  tokenEndpoint: 'https://accounts.spotify.com/api/token',
+};
+
+const clientId = '211a9538951e4302b2a20c1e1ada5f4d';
+const scopes = ["user-read-email", "playlist-read-private", "user-library-read"]
+
+export default function LoginScreen() {
+  const router = useRouter();
+
+  const [request, response, promptAsync] = AuthSession.useAuthRequest(
+      {
+        clientId,
+        scopes,
+        redirectUri: REDIRECT_URL,
+        usePKCE: false,
+        responseType: AuthSession.ResponseType.Code,
+      },
+      discovery
+  );
+
+  React.useEffect(() => {
+    if (response?.type === 'success' && response.params?.code) {
+      router.replace({ pathname: '/callback', params: { code: response.params.code } });
+    }
+
+  }, [response]);
+
+  return (
+      <View style={{ flex: 1, alignItems: 'center', justifyContent: 'center' }}>
+        <Button
+            title="Se connecter avec Spotify"
+            onPress={() => promptAsync()}
+            disabled={!request}
+        />
+      </View>
+  );
+}

--- a/moodsound_app/src/app/test-mood.tsx
+++ b/moodsound_app/src/app/test-mood.tsx
@@ -1,0 +1,31 @@
+import { View, Button } from 'react-native';
+import { useState } from 'react';
+import { useRouter } from 'expo-router';
+import CameraStep from '../components/CameraStep';
+import MicrophoneStep from '../components/MicrophoneStep';
+import ActivityStep from '../components/ActivityStep';
+
+export default function TestMoodScreen() {
+  const [step, setStep] = useState(1);
+  const router = useRouter();
+
+  const next = () => {
+    if (step < 3) {
+      setStep(step + 1);
+    } else {
+      router.replace('/');
+    }
+  };
+
+  let content;
+  if (step === 1) content = <CameraStep />;
+  else if (step === 2) content = <MicrophoneStep />;
+  else content = <ActivityStep />;
+
+  return (
+    <View style={{ flex: 1, alignItems: 'center', justifyContent: 'center' }}>
+      {content}
+      <Button title={step < 3 ? 'Suivant' : 'Terminer'} onPress={next} />
+    </View>
+  );
+}

--- a/moodsound_app/src/components/ActivityStep.tsx
+++ b/moodsound_app/src/components/ActivityStep.tsx
@@ -1,0 +1,9 @@
+import { View, Text } from 'react-native';
+
+export default function ActivityStep() {
+  return (
+    <View style={{ alignItems: 'center', justifyContent: 'center' }}>
+      <Text style={{ color: 'white' }}>Activity step</Text>
+    </View>
+  );
+}

--- a/moodsound_app/src/components/CameraStep.tsx
+++ b/moodsound_app/src/components/CameraStep.tsx
@@ -1,0 +1,9 @@
+import { View, Text } from 'react-native';
+
+export default function CameraStep() {
+  return (
+    <View style={{ alignItems: 'center', justifyContent: 'center' }}>
+      <Text style={{ color: 'white' }}>Camera step</Text>
+    </View>
+  );
+}

--- a/moodsound_app/src/components/Header.tsx
+++ b/moodsound_app/src/components/Header.tsx
@@ -1,0 +1,25 @@
+import React from 'react';
+import { View, Button } from 'react-native';
+import { useSafeAreaInsets } from 'react-native-safe-area-context';
+import { useAuth } from '../services/auth';
+
+export default function Header() {
+  const insets = useSafeAreaInsets();
+  const { logout, isAuthenticated } = useAuth();
+
+  if (!isAuthenticated) return null;
+
+  return (
+    <View
+      style={{
+        paddingTop: insets.top,
+        paddingBottom: 10,
+        backgroundColor: '#222',
+        alignItems: 'flex-end',
+        paddingHorizontal: 10,
+      }}
+    >
+      <Button title="Logout" onPress={logout} />
+    </View>
+  );
+}

--- a/moodsound_app/src/components/MicrophoneStep.tsx
+++ b/moodsound_app/src/components/MicrophoneStep.tsx
@@ -1,0 +1,9 @@
+import { View, Text } from 'react-native';
+
+export default function MicrophoneStep() {
+  return (
+    <View style={{ alignItems: 'center', justifyContent: 'center' }}>
+      <Text style={{ color: 'white' }}>Microphone step</Text>
+    </View>
+  );
+}

--- a/moodsound_app/src/components/__tests__/__snapshots__/StyledText-test.js.snap
+++ b/moodsound_app/src/components/__tests__/__snapshots__/StyledText-test.js.snap
@@ -1,0 +1,9 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`renders correctly 1`] = `
+<Text
+  className="text-light-text font-[SpaceMono]"
+>
+  Snapshot test!
+</Text>
+`;

--- a/moodsound_app/src/services/AuthGuard.tsx
+++ b/moodsound_app/src/services/AuthGuard.tsx
@@ -1,0 +1,26 @@
+import { useRouter, useSegments } from 'expo-router';
+import { useEffect } from 'react';
+import { useAuth } from './auth';
+
+export default function AuthGuard({ children }: { children: React.ReactNode }) {
+  const { isAuthenticated, loading } = useAuth();
+  const segments = useSegments();
+  const router = useRouter();
+
+  useEffect(() => {
+    if (loading) return;
+    const inAuthFlow = segments[0] === 'login' || segments[0] === 'callback';
+    if (!isAuthenticated && !inAuthFlow) {
+      router.replace('/login');
+    }
+    if (isAuthenticated && inAuthFlow) {
+      router.replace('/');
+    }
+  }, [segments, isAuthenticated, loading]);
+
+  if (loading) {
+    return null;
+  }
+
+  return <>{children}</>;
+}

--- a/moodsound_app/src/services/api.ts
+++ b/moodsound_app/src/services/api.ts
@@ -1,0 +1,44 @@
+export const API_BASE_URL = "http://192.168.1.186:8000/api" //"http://10.109.255.231:8000/api";
+export const REDIRECT_URL ="exp://192.168.1.186:8081/callback" //"exp://10.109.255.231:8081/callback"
+interface RequestOptions {
+  headers?: Record<string, string>;
+}
+
+async function request<T>(method: string, path: string, body?: unknown, options: RequestOptions = {}): Promise<T> {
+  const response = await fetch(`${API_BASE_URL}${path}`, {
+    method,
+    headers: {
+      'Content-Type': 'application/json',
+      ...(options.headers ?? {}),
+    },
+    body: body ? JSON.stringify(body) : undefined,
+  });
+
+  if (!response.ok) {
+    const errorText = await response.text();
+    throw new Error(errorText || response.statusText);
+  }
+
+  if (response.status === 204) {
+    return undefined as T;
+  }
+
+  return (await response.json()) as T;
+}
+
+export const api = {
+  get<T>(path: string, options?: RequestOptions) {
+    return request<T>('GET', path, undefined, options);
+  },
+  post<T>(path: string, body?: unknown, options?: RequestOptions) {
+    return request<T>('POST', path, body, options);
+  },
+  patch<T>(path: string, body?: unknown, options?: RequestOptions) {
+    return request<T>('PATCH', path, body, options);
+  },
+  delete<T>(path: string, body?: unknown, options?: RequestOptions) {
+    return request<T>('DELETE', path, body, options);
+  },
+};
+
+export default api;

--- a/moodsound_app/src/services/auth.tsx
+++ b/moodsound_app/src/services/auth.tsx
@@ -1,0 +1,62 @@
+import React, { createContext, useContext, useState, useEffect } from 'react';
+import * as SecureStore from 'expo-secure-store';
+
+export interface TokenData {
+  access_token: string;
+  expires_in: number;
+}
+
+const TOKEN_KEY = 'spotify_token';
+const EXPIRES_KEY = 'spotify_token_expires';
+
+interface AuthContextValue {
+  token: string | null;
+  isAuthenticated: boolean;
+  loading: boolean;
+  setToken: (data: TokenData) => Promise<void>;
+  logout: () => Promise<void>;
+}
+
+const AuthContext = createContext<AuthContextValue | undefined>(undefined);
+
+export function AuthProvider({ children }: { children: React.ReactNode }) {
+  const [token, setTokenState] = useState<string | null>(null);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    async function load() {
+      const stored = await SecureStore.getItemAsync(TOKEN_KEY);
+      const expires = await SecureStore.getItemAsync(EXPIRES_KEY);
+      if (stored && expires && parseInt(expires, 10) > Date.now() / 1000) {
+        setTokenState(stored);
+      }
+      setLoading(false);
+    }
+    load();
+  }, []);
+
+  const setToken = async (data: TokenData) => {
+    const expiresAt = Math.floor(Date.now() / 1000 + data.expires_in - 60);
+    await SecureStore.setItemAsync(TOKEN_KEY, data.access_token);
+    await SecureStore.setItemAsync(EXPIRES_KEY, expiresAt.toString());
+    setTokenState(data.access_token);
+  };
+
+  const logout = async () => {
+    await SecureStore.deleteItemAsync(TOKEN_KEY);
+    await SecureStore.deleteItemAsync(EXPIRES_KEY);
+    setTokenState(null);
+  };
+
+  return (
+    <AuthContext.Provider value={{ token, isAuthenticated: !!token, loading, setToken, logout }}>
+      {children}
+    </AuthContext.Provider>
+  );
+}
+
+export function useAuth() {
+  const ctx = useContext(AuthContext);
+  if (!ctx) throw new Error('useAuth must be used within AuthProvider');
+  return ctx;
+}


### PR DESCRIPTION
## Summary
- add Spotify login screens and mood test screens
- port API helpers and Auth provider from frontend
- show logout header and guard routes with AuthGuard
- wrap navigation with AuthProvider in RootLayout
- update snapshot

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_68794ff3839c832dadfbd71b688f164e