### PR TITLE
Add accelerometer display

### DIFF
--- a/frontend/components/ActivityStep.tsx
+++ b/frontend/components/ActivityStep.tsx
@@ -1,9 +1,38 @@
+import React, { useEffect, useState } from 'react';
 import { View, Text } from 'react-native';
+import { Accelerometer } from 'expo-sensors';
+import type { Subscription } from 'expo-modules-core';
 
 export default function ActivityStep() {
+  const [data, setData] = useState({ x: 0, y: 0, z: 0 });
+
+  useEffect(() => {
+    let subscription: Subscription | null = null;
+
+    async function subscribe() {
+      const { status } = await Accelerometer.requestPermissionsAsync();
+      if (status !== 'granted') {
+        return;
+      }
+
+      subscription = Accelerometer.addListener(setData);
+      Accelerometer.setUpdateInterval(500);
+    }
+
+    subscribe();
+
+    return () => {
+      if (subscription) {
+        subscription.remove();
+      }
+    };
+  }, []);
+
   return (
     <View style={{ alignItems: 'center', justifyContent: 'center' }}>
-      <Text style={{ color: 'white' }}>Activity step</Text>
+      <Text style={{ color: 'white' }}>x: {data.x.toFixed(2)}</Text>
+      <Text style={{ color: 'white' }}>y: {data.y.toFixed(2)}</Text>
+      <Text style={{ color: 'white' }}>z: {data.z.toFixed(2)}</Text>
     </View>
   );
 }


### PR DESCRIPTION
## Summary
- show accelerometer values in `ActivityStep`

## Testing
- `npm install`
- `npx eslint components/ActivityStep.tsx`

------
https://chatgpt.com/codex/tasks/task_e_687a874701e0832d9b9eb548e2f8608d