### PR TITLE
Add microphone recording step

### DIFF
--- a/frontend/components/MicrophoneStep.tsx
+++ b/frontend/components/MicrophoneStep.tsx
@@ -1,9 +1,67 @@
-import { View, Text } from 'react-native';
+import { View, Text, Button } from 'react-native';
+import { useEffect, useState } from 'react';
+import { Audio } from 'expo-av';
 
 export default function MicrophoneStep() {
+  const [recording, setRecording] = useState<Audio.Recording | null>(null);
+  const [uri, setUri] = useState<string | null>(null);
+
+  useEffect(() => {
+    Audio.requestPermissionsAsync();
+  }, []);
+
+  useEffect(() => {
+    return () => {
+      if (recording) {
+        recording.stopAndUnloadAsync().catch(() => {});
+      }
+    };
+  }, [recording]);
+
+  const startRecording = async () => {
+    try {
+      const { granted } = await Audio.requestPermissionsAsync();
+      if (!granted) return;
+
+      await Audio.setAudioModeAsync({
+        allowsRecordingIOS: true,
+        playsInSilentModeIOS: true,
+      });
+
+      const rec = new Audio.Recording();
+      await rec.prepareToRecordAsync(
+        Audio.RECORDING_OPTIONS_PRESET_HIGH_QUALITY,
+      );
+      await rec.startAsync();
+      setRecording(rec);
+      setUri(null);
+    } catch (err) {
+      console.error('Failed to start recording', err);
+    }
+  };
+
+  const stopRecording = async () => {
+    if (!recording) return;
+    try {
+      await recording.stopAndUnloadAsync();
+      const uri = recording.getURI();
+      setUri(uri);
+    } catch (err) {
+      console.error('Failed to stop recording', err);
+    } finally {
+      setRecording(null);
+    }
+  };
+
   return (
     <View style={{ alignItems: 'center', justifyContent: 'center' }}>
-      <Text style={{ color: 'white' }}>Microphone step</Text>
+      <Button
+        title={recording ? 'Stop Recording' : 'Start Recording'}
+        onPress={recording ? stopRecording : startRecording}
+      />
+      {uri && (
+        <Text style={{ color: 'white', marginTop: 10 }}>Fichier: {uri}</Text>
+      )}
     </View>
   );
 }


### PR DESCRIPTION
## Summary
- enable audio recording in `MicrophoneStep`
- request permissions, start/stop recording, show recorded file path

## Testing
- `npm run lint` *(fails: expo not found)*

------
https://chatgpt.com/codex/tasks/task_e_687a876dd9d8832da969408d99b75b9e