### PR TITLE
Implement mood context and store step data

### DIFF
--- a/frontend/app/_layout.tsx
+++ b/frontend/app/_layout.tsx
@@ -7,6 +7,7 @@ import './global.css'
 
 import { useColorScheme } from 'react-native';
 import { AuthProvider } from '../services/auth';
+import { MoodProvider } from '../services/mood';
 import Header from '../components/Header';
 
 export default function RootLayout() {
@@ -22,16 +23,18 @@ export default function RootLayout() {
 
   return (
     <ThemeProvider value={colorScheme === 'dark' ? DarkTheme : DefaultTheme}>
-      <AuthProvider>
-        <Header />
-        <Stack>
+      <MoodProvider>
+        <AuthProvider>
+          <Header />
+          <Stack>
             <Stack.Screen name="index" options={{ title: 'Home' }} />
             <Stack.Screen name="login" options={{ title: 'Login' }} />
             <Stack.Screen name="callback" options={{ headerShown: false }} />
             <Stack.Screen name="connected" options={{ title: 'Connected' }} />
             <Stack.Screen name="test-mood" options={{ title: 'Test Mood' }} />
           </Stack>
-      </AuthProvider>
+        </AuthProvider>
+      </MoodProvider>
       <StatusBar style="auto" />
     </ThemeProvider>
   );

--- a/frontend/components/ActivityStep.tsx
+++ b/frontend/components/ActivityStep.tsx
@@ -1,5 +1,6 @@
 import React, { useEffect, useRef, useState } from 'react';
 import { View, Text, Button } from 'react-native';
+import { useMood } from '../services/mood';
 import { Accelerometer } from 'expo-sensors';
 import * as Location from 'expo-location';
 import {LocationSubscription} from "expo-location";
@@ -40,6 +41,8 @@ export default function ActivityStep() {
   const [isRecording, setIsRecording] = useState(false);
   const [country, setCountry] = useState<string | null>(null);
   const [region, setRegion] = useState<string | null>(null);
+
+  const { setActivityData } = useMood();
 
   const normArray:React.RefObject<number[]> = useRef([0]);
   const speedArray:React.RefObject<number[]> = useRef([]);
@@ -122,8 +125,13 @@ export default function ActivityStep() {
     const geoResult = await fetchCountryAndRegion();
 
     if (geoResult) {
-
-      //TODO Stocker geoResult, activityLevel et speedLevel dans un service/contexte pour le réutiliser plus tard
+      // Store activity and location data in context for later use
+      setActivityData({
+        activityLevel: actLevel,
+        speedLevel: spdLevel,
+        country: geoResult.country,
+        region: geoResult.region,
+      });
     }
   };
 

--- a/frontend/components/MicrophoneStep.tsx
+++ b/frontend/components/MicrophoneStep.tsx
@@ -1,10 +1,12 @@
 import { View, Text, Button } from 'react-native';
 import { useEffect, useState } from 'react';
+import { useMood } from '../services/mood';
 import { Audio } from 'expo-av';
 
 export default function MicrophoneStep() {
   const [recording, setRecording] = useState<Audio.Recording | null>(null);
   const [uri, setUri] = useState<string | null>(null);
+  const { setAudioUri } = useMood();
 
   useEffect(() => {
     Audio.requestPermissionsAsync();
@@ -30,7 +32,8 @@ export default function MicrophoneStep() {
 
       const rec = new Audio.Recording();
       await rec.prepareToRecordAsync(
-        Audio.RECORDING_OPTIONS_PRESET_HIGH_QUALITY,
+        // Use high quality preset for recording
+        Audio.RecordingOptionsPresets.HIGH_QUALITY,
       );
       await rec.startAsync();
       setRecording(rec);
@@ -47,7 +50,8 @@ export default function MicrophoneStep() {
       const uri = recording.getURI();
       setUri(uri);
 
-      //TODO Stocker l'audio dans un service/contexte pour le réutiliser plus tard
+      // Store audio uri in context for later use
+      setAudioUri(uri ?? null);
 
     } catch (err) {
       console.error('Failed to stop recording', err);

--- a/frontend/services/mood.tsx
+++ b/frontend/services/mood.tsx
@@ -1,0 +1,38 @@
+import React, { createContext, useContext, useState } from 'react';
+
+export interface ActivityData {
+  activityLevel: string | null;
+  speedLevel: string | null;
+  country: string | null;
+  region: string | null;
+}
+
+interface MoodContextValue {
+  audioUri: string | null;
+  setAudioUri: (uri: string | null) => void;
+  activityData: ActivityData | null;
+  setActivityData: (data: ActivityData) => void;
+}
+
+const MoodContext = createContext<MoodContextValue | undefined>(undefined);
+
+export function MoodProvider({ children }: { children: React.ReactNode }) {
+  const [audioUri, setAudioUri] = useState<string | null>(null);
+  const [activityData, setActivityDataState] = useState<ActivityData | null>(null);
+
+  const setActivityData = (data: ActivityData) => {
+    setActivityDataState(data);
+  };
+
+  return (
+    <MoodContext.Provider value={{ audioUri, setAudioUri, activityData, setActivityData }}>
+      {children}
+    </MoodContext.Provider>
+  );
+}
+
+export function useMood() {
+  const ctx = useContext(MoodContext);
+  if (!ctx) throw new Error('useMood must be used within MoodProvider');
+  return ctx;
+}


### PR DESCRIPTION
## Summary
- add `MoodProvider` context to hold audio and activity data
- wrap app in `MoodProvider`
- save audio URI from `MicrophoneStep` into context
- save activity and location data from `ActivityStep` into context

## Testing
- `npm install`
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_687b927c2a18832d8d5c1876bb14f7ed