### PR TITLE
Add test-mood endpoint

### DIFF
--- a/backend/api/urls.py
+++ b/backend/api/urls.py
@@ -4,4 +4,5 @@ from . import views
 urlpatterns = [
     path('spotify/token/', views.spotify_token, name='spotify-token'),
     path('spotify/favorites/', views.spotify_favorites, name='spotify-favorites'),
+    path('test-mood/', views.test_mood, name='test-mood'),
 ]

--- a/backend/api/views.py
+++ b/backend/api/views.py
@@ -1,8 +1,7 @@
 import requests
-import urllib.parse
 from django.conf import settings
 import json
-from django.http import HttpResponseRedirect, JsonResponse, HttpResponse
+from django.http import JsonResponse, HttpResponse
 from django.views.decorators.csrf import csrf_exempt
 
 client_id = settings.SPOTIFY_CLIENT_ID
@@ -58,3 +57,19 @@ def spotify_favorites(request):
 
     print(r.json(), flush=True)
     return JsonResponse(r.json())
+
+
+@csrf_exempt
+def test_mood(request):
+    """Temporary endpoint to receive mood data from the mobile app."""
+    if request.method != "POST":
+        return HttpResponse(status=405)
+
+    try:
+        data = json.loads(request.body)
+    except Exception:
+        return JsonResponse({"error": "invalid json"}, status=400)
+
+    # For now we simply echo the received payload and log it server side
+    print(data, flush=True)
+    return JsonResponse({"status": "received", "data": data})


### PR DESCRIPTION
## Summary
- support /api/test-mood for sending mood data

## Testing
- `ruff check .`
- `python manage.py test` *(fails: settings.DATABASES is improperly configured)*

------
https://chatgpt.com/codex/tasks/task_e_687bb6940050832dbddd7ef4dfe25c86