### PR TITLE
Implement async video/audio uploads

### DIFF
--- a/frontend/app/test-mood.tsx
+++ b/frontend/app/test-mood.tsx
@@ -17,6 +17,10 @@ export default function TestMoodScreen() {
   const router = useRouter();
 
   const {
+    audioUrl,
+    videoUrl,
+    audioUploading,
+    videoUploading,
     audioUri,
     videoUri,
     activityData,
@@ -35,9 +39,12 @@ export default function TestMoodScreen() {
   };
 
   async function sendToBackend() {
+    while (audioUploading || videoUploading) {
+      await new Promise(res => setTimeout(res, 500));
+    }
     const payload = {
-      audioUri,
-      videoUri,
+      audioUrl,
+      videoUrl,
       activityData,
       happiness,
       energy,

--- a/frontend/services/api.ts
+++ b/frontend/services/api.ts
@@ -5,6 +5,28 @@ interface RequestOptions {
   headers?: Record<string, string>;
 }
 
+async function uploadFile(endpoint: string, uri: string, mime: string): Promise<string> {
+  const formData = new FormData();
+  formData.append('file', {
+    uri,
+    name: uri.split('/').pop() || 'upload',
+    type: mime,
+  } as any);
+
+  const response = await fetch(`${API_BASE_URL}${endpoint}`, {
+    method: 'POST',
+    body: formData,
+  });
+
+  if (!response.ok) {
+    const errorText = await response.text();
+    throw new Error(errorText || response.statusText);
+  }
+
+  const data = await response.json();
+  return data.url as string;
+}
+
 async function request<T>(method: string, path: string, body?: unknown, options: RequestOptions = {}): Promise<T> {
   const response = await fetch(`${API_BASE_URL}${path}`, {
     method,
@@ -40,6 +62,13 @@ export const api = {
   delete<T>(path: string, body?: unknown, options?: RequestOptions) {
     return request<T>('DELETE', path, body, options);
   },
+  uploadAudio(uri: string) {
+    return uploadFile('/upload-audio/', uri, 'audio/m4a');
+  },
+  uploadVideo(uri: string) {
+    return uploadFile('/upload-video/', uri, 'video/mp4');
+  },
 };
 
 export default api;
+

--- a/frontend/services/mood.tsx
+++ b/frontend/services/mood.tsx
@@ -14,8 +14,16 @@ export interface EnvironnementData{
 export interface MoodContextValue {
     audioUri: string | null;
     setAudioUri: (uri: string | null) => void;
+    audioUrl: string | null;
+    setAudioUrl: (url: string | null) => void;
+    audioUploading: boolean;
+    setAudioUploading: (v: boolean) => void;
     videoUri: string | null;
     setVideoUri: (uri: string | null) => void;
+    videoUrl: string | null;
+    setVideoUrl: (url: string | null) => void;
+    videoUploading: boolean;
+    setVideoUploading: (v: boolean) => void;
     activityData: ActivityData | null;
     setActivityData: (data: ActivityData) => void;
     happiness: string | null;
@@ -30,7 +38,11 @@ const MoodContext = createContext<MoodContextValue | undefined>(undefined);
 
 export function MoodProvider({ children }: { children: React.ReactNode }) {
     const [audioUri, setAudioUri] = useState<string | null>(null);
+    const [audioUrl, setAudioUrl] = useState<string | null>(null);
+    const [audioUploading, setAudioUploading] = useState<boolean>(false);
     const [videoUri, setVideoUri] = useState<string | null>(null);
+    const [videoUrl, setVideoUrl] = useState<string | null>(null);
+    const [videoUploading, setVideoUploading] = useState<boolean>(false);
     const [activityData, setActivityDataState] = useState<ActivityData | null>(null);
     const [happiness, setHappiness] = useState<string | null>(null);
     const [energy, setEnergy] = useState<string | null>(null);
@@ -45,8 +57,16 @@ export function MoodProvider({ children }: { children: React.ReactNode }) {
             value={{
                 audioUri,
                 setAudioUri,
+                audioUrl,
+                setAudioUrl,
+                audioUploading,
+                setAudioUploading,
                 videoUri,
                 setVideoUri,
+                videoUrl,
+                setVideoUrl,
+                videoUploading,
+                setVideoUploading,
                 activityData,
                 setActivityData,
                 happiness,


### PR DESCRIPTION
## Summary
- add audio/video upload status and URLs to mood context
- implement multipart upload helpers in `api.ts`
- upload audio after recording and video after recording
- show simple upload status/errors
- wait for uploads before sending final payload

## Testing
- `npm run lint` *(fails: `expo` not found)*

------
https://chatgpt.com/codex/tasks/task_e_687be7ec4590832d8da0e42b301456a8